### PR TITLE
Ability to Set LESS variables via $lessVariables

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1658,6 +1658,17 @@ class lessc {
 
 		$this->buffer = $this->removeComments($buff);
 		$this->pushBlock(null); // set up global scope
+		
+		// prepend user defined variables at the top of the buffer
+		if(!empty($this->lessVariables)) {
+			$bufferPrepend = '';
+			
+			foreach($this->lessVariables as $key => $value) {
+				$bufferPrepend .= $this->vPrefix.$key.':'.$value.";\n";
+			}
+			
+			$this->buffer = $bufferPrepend.$this->buffer;
+		}
 
 		// trim whitespace on head
 		if (preg_match('/^\s+/', $this->buffer, $m)) {


### PR DESCRIPTION
I needed the ability to easily define dynamic LESS variables via PHP. This allows you to set an associated array on the lessc's $lessVariables property which is then converted into LESS variable definitions and prepended on the LESS buffer before compilation.
