### PR TITLE
Passing php vars into ccompile and cexecute

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1886,10 +1886,11 @@ class lessc {
 
 
 	// compile to $in to $out if $in is newer than $out
+	// force rebuilding by setting $force to true
 	// use $vars to pass in variables from php
 	// returns true when it compiles, false otherwise
-	public static function ccompile($in, $out, $vars = array()) {
-		if (!is_file($out) || filemtime($in) > filemtime($out)) {
+	public static function ccompile($in, $out, $vars = array(), $force = false) {
+		if (!is_file($out) || filemtime($in) > filemtime($out) || $force) {
 			$less = new lessc($in);
 			file_put_contents($out, $less->parse(null,$vars));
 			return true;
@@ -1941,6 +1942,10 @@ class lessc {
 						break;
 					}
 				}
+			} elseif (isset($in['vars']) and $vars !== $in['vars']) {
+				// If the variables we're passing in have changed
+				// we should look at the incoming root to trigger a rebuild.
+				$root = $in['root'];
 			}
 		} else {
 			// TODO: Throw an exception? We got neither a string nor something
@@ -1956,6 +1961,7 @@ class lessc {
 			$out['compiled'] = $less->parse(null,$vars);
 			$out['files'] = $less->allParsedFiles();
 			$out['updated'] = time();
+			$out['vars'] = $vars;
 			return $out;
 		} else {
 			// No changes, pass back the structure


### PR DESCRIPTION
Hello Mr Leafo,

At least one bit of this request would be good to have - I can understand if you wish to keep ccompile simple.

I've added a means of passing variables into cexecute and comparing the cache against the passed in vars to make it recompile if they change.

With ccompile I've added a $vars parameter and also a force parameter so that developers can decide for themselves using their own database or cache of the variables to decide if the file needs recompiling.

Passing the variables in is especially useful for me as it allows me to pass in data from the cms to use within .less files. I have a wordpress based auto compiler that I want to use it with at https://github.com/sanchothefat/wp-less

Using the methods is much more straightforward than rolling my own caching mechanism.

Let me know what you think and any changes you'd like me to make if you do want to pull the changes.
