### PR TITLE
Getopt and cmdline help

### DIFF
--- a/tests/test.php
+++ b/tests/test.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 error_reporting(E_ALL);
 


### PR DESCRIPTION
provides command line help and a few other tidbits for the test runner (for example: not everybody has 'meld'; every UNIX has 'diff' though, so a couple of options allow users to use that one as described in the './test.php -h' output.

The #! /usr/bin/env php bang is used because a lot of UNIXes have php not in /usr/bin but somewhere else in the search path (possibly /usr/local/bin but that's not a guarantee either; 'env' will resolve the conundrum)
