### PR TITLE
Added: red(), green(), and blue() functions

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1538,6 +1538,34 @@ class lessc {
 			isset($color[4]) ? $color[4]*255 : 0,
 			$color[1],$color[2], $color[3]);
 	}
+
+	function lib_red($color){
+		$color = $this->coerceColor($color);
+		if (is_null($color)) {
+			$this->throwError('color expected for red()');
+		}
+		
+		return $color[1];
+	}
+
+	function lib_green($color){
+		$color = $this->coerceColor($color);
+		if (is_null($color)) {
+			$this->throwError('color expected for green()');
+		}
+		
+		return $color[2];
+	}
+
+	function lib_blue($color){
+		$color = $this->coerceColor($color);
+		if (is_null($color)) {
+			$this->throwError('color expected for blue()');
+		}
+		
+		return $color[3];
+	}
+
 	
 	function lib_argb($color){
             return $this->lib_rgbahex($color);

--- a/tests/inputs/colors.less
+++ b/tests/inputs/colors.less
@@ -1,5 +1,9 @@
 
 body {
+	color:rgb(red(#f00), red(#0F0), red(#00f));
+	color:rgb(red(#f00), green(#0F0), blue(#00f));
+	color:rgb(red(#0ff), green(#f0f), blue(#ff0));
+
 	color: hsl(34, 50%, 40%);
 	color: hsla(34, 50%, 40%, 0.3);
 

--- a/tests/outputs/colors.css
+++ b/tests/outputs/colors.css
@@ -1,4 +1,7 @@
 body {
+  color:#ff0000;
+  color:#ffffff;
+  color:#000000;
   color:#996d33;
   color:rgba(153,109,51,0.3);
   lighten:#ffffff;


### PR DESCRIPTION
They work much like hue(),
    saturation() and lightness() except that they return a unitless
    scalar between 0 and 255 for their respective color components,
    much like the expected inputs to rgb()
Added: tests for new functions to colors.less and colors.css
