### PR TITLE
Composer support for LessPHP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /*.css
 tests/bootstrap
 tests/tmp
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "leafo/lessphp",
+    "type": "library",
+    "description": "lessphp is a compiler for LESS written in PHP.",
+    "homepage": "http://leafo.net/lessphp/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "leafo",
+            "homepage": "http://leafo.net"
+        }
+    ],
+    "autoload": {
+        "classmap": ["lessc.inc.php", "lessify.inc.php"]
+    }
+}


### PR DESCRIPTION
Following up on the discussions in #216, [Composer](http://getcomposer.org/) is a dependency management system for PHP packages. This pull request adds Composer support to LessPHP. Having this means that a project can use something like the following in a composer.json to depict a dependency on LessPHP:

```
"require": {
    "leafo/lessphp": "*"
}
```

The client application would not have to write require "lessify.inc.php" at all as the classes would be autoloaded when used.
