### PR TITLE
Support for providing instance for lessc::cexecute via callback returning instance of lessc

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1440,9 +1440,10 @@ class lessc {
 	 *
 	 * @param mixed $in Input
 	 * @param bool $force Force rebuild?
+	 * @param callable $instance Callback which should return lessc instance
 	 * @return array lessphp cache structure
 	 */
-	public static function cexecute($in, $force = false) {
+	public static function cexecute($in, $force = false, $instanceCallback = null) {
 
 		// assume no root
 		$root = null;
@@ -1473,7 +1474,7 @@ class lessc {
 
 		if ($root !== null) {
 			// If we have a root value which means we should rebuild.
-			$less = new lessc($root);
+			$less = is_callable($instanceCallback) ? call_user_func($instanceCallback, $root) : new lessc($root);
 			$out = array();
 			$out['root'] = $root;
 			$out['compiled'] = $less->parse();


### PR DESCRIPTION
I use callback to create `lessc` instance only when it is needed (some kind of lazy initialization).

It can be used for PHP 5.3 with anonymous functions:

``` php
// PHP 5.3 anonymous function

// from http://leafo.net/lessphp/docs/#compiling_automatically
function auto_compile_less($less_fname, $css_fname) {
  // load the cache
  $cache_fname = $less_fname.".cache";
  if (file_exists($cache_fname)) {
    $cache = unserialize(file_get_contents($cache_fname));
  } else {
    $cache = $less_fname;
  }

  $new_cache = lessc::cexecute($cache, true, function($root) {
    $instance = new lessc($root);
    $instance->setFormatter('compressed');
    return $instance;
  });
  if (!is_array($cache) || $new_cache['updated'] > $cache['updated']) {
    file_put_contents($cache_fname, serialize($new_cache));
    file_put_contents($css_fname, $new_cache['compiled']);
  }
}

auto_compile_less('myfile.less', 'myfile.css');
```

And with PHP 5.2 with any `call_user_func` argument:

``` php
// PHP 5.2: pass function by name

// from http://leafo.net/lessphp/docs/#compiling_automatically
function auto_compile_less($less_fname, $css_fname) {
  // load the cache
  $cache_fname = $less_fname.".cache";
  if (file_exists($cache_fname)) {
    $cache = unserialize(file_get_contents($cache_fname));
  } else {
    $cache = $less_fname;
  }

   function instance($root) {
    $instance = new lessc($root);
    $instance->setFormatter('compressed');
    return $instance;
  };

  $new_cache = lessc::cexecute($cache, true, 'instance');
  if (!is_array($cache) || $new_cache['updated'] > $cache['updated']) {
    file_put_contents($cache_fname, serialize($new_cache));
    file_put_contents($css_fname, $new_cache['compiled']);
  }
}

auto_compile_less('myfile.less', 'myfile.css');
```

I can't find anywhere which is a minimal PHP version required for lessphp.
