### PR TITLE
Support percent based keyframe rules that are decimal percentages

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1979,7 +1979,7 @@ class lessc_parser {
 	protected function keyframeTags(&$tags) {
 		$s = $this->seek();
 		$tags = array();
-		while($this->match("(to|from|[0-9]+%)", $m)) {
+		while($this->match("(to|from|[0-9]+(?:\.[0-9]+)?%)", $m)) {
 			$tags[] = $m[1];
 			if (!$this->literal(",")) break;
 		}


### PR DESCRIPTION
One liner change to support decimal percentages in keyframe blocks. Ran into this issue using it with the video-js css, which contains this section: https://github.com/zencoder/video-js/blob/master/design/video-js.css#L378
