### PR TITLE
Use the php in the path

### DIFF
--- a/plessc
+++ b/plessc
@@ -1,4 +1,4 @@
-#!/usr/bin/php -q
+#!/usr/bin/env php -q
 <?php
 // Command line utility to compile LESS to STDOUT
 // Leaf Corcoran <leafot@gmail.com>, 2012


### PR DESCRIPTION
I'm running lessphp on a mac, with PHP in /usr/local/bin, rather than the stock MacOS PHP in /usr/bin

If you use /usr/bin/env php rather than /usr/bin/php in the shebang at the start of plessc, it'll use the same PHP a user would get on the commandline typing 'php'.

This is portable to every unix out there.
