### PR TITLE
Partial fix for #311, updated checkedCompile to allow for an array of files

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1619,11 +1619,38 @@ class lessc {
 		return $out;
 	}
 
-	// compile only if changed input has changed or output doesn't exist
-	public function checkedCompile($in, $out) {
-		if (!is_file($out) || filemtime($in) > filemtime($out)) {
-			$this->compileFile($in, $out);
-			return true;
+	/*
+	* Checks 1 or more files modified time to see if they are newer then the output file.
+	* If a file is newer then the output file, it compiles the file into the output file.
+	*
+	* @param mixed $in: 1 filename or an array of filenames to be checked against.
+	* @param string filename $out: the output file to compare the time against.
+	* @param string filename $fileToCompile: if passing an array, the file to compile if
+	*		one of the files is newer then the output.
+	*/
+	public function checkedCompile($in, $out, $fileToCompile = NULL) {
+		if( is_array($in) )
+		{
+			if( !isset( $fileToCompile ))
+			{
+				throw new Exception('The 3rd argument must be set as the file you want compiled if one fo the files is newer');
+			}
+			
+			foreach( $in as $file )
+			{
+				if(!is_file($out) || filemtime($file) > filemtime($out))
+				{
+					$this->compileFile($fileToCompile, $out);
+					return true;
+				}
+			}
+		}else
+		{
+			if (!is_file($out) || filemtime($in) > filemtime($out)) 
+			{
+				$this->compileFile($in, $out);
+				return true;
+			}
 		}
 		return false;
 	}


### PR DESCRIPTION
I've updated the checkedCompile method to allow for multiple files to be checked instead of just the input.

```
/*
* Checks 1 or more files modified time to see if they are newer then the output file.
* If a file is newer then the output file, it compiles the file into the output file.
*
* @param mixed $in: 1 filename or an array of filenames to be checked against.
* @param string filename $out: the output file to compare the time against.
* @param string filename $fileToCompile: if passing an array, the file to compile if
*       one of the files is newer then the output.
*/
public function checkedCompile($in, $out, $fileToCompile = NULL) {
    if( is_array($in) )
    {
        if( !isset( $fileToCompile ))
        {
            throw new Exception('The 3rd argument must be set as the file you want compiled if one fo the files is newer');
        }

        foreach( $in as $file )
        {
            if(!is_file($out) || filemtime($file) > filemtime($out))
            {
                $this->compileFile($fileToCompile, $out);
                return true;
            }
        }
    }else
    {
        if (!is_file($out) || filemtime($in) > filemtime($out)) 
        {
            $this->compileFile($in, $out);
            return true;
        }
    }
    return false;
}
```

And it can be used as such like this to check any of your less files for the modified time to be greater then the modified time on the output file
You can also still use the original way, with no problems as shown with the admin section.

```
require 'lessc.inc.php';

$less = new lessc;
$less->setFormatter("classic");
if (array_key_exists('HTTP_HOST', $_SERVER))
{
    if (stripos($_SERVER['REQUEST_URI'], 'admin') !== FALSE)
    {
        try
        {
            $less->checkedCompile('less/admin.less', 'css/admin.css');
        } catch (exception $ex)
        {
            exit('lessc fatal error:<br />'.$ex->getMessage());
        }
    }else
    {
        $file_array = array
        (
            'less/common.less', 
            'less/input.less',
            'less/mixins.less',
            'less/reset.less',
            'less/site.less'
        );
        try 
        {
            $less->checkedCompile($file_array, 'css/site.css', 'less/input.less');
        } catch (exception $ex) 
        {
            exit('lessc fatal error:<br />'.$ex->getMessage());
        }
    }
}
```

Where the file_array is the list of all your less files, input.less is the main less file that imports all the files, and site.css is the output file. 
