### PR TITLE
Remove duplicate properties in lessc compileProp()

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -708,7 +708,7 @@ class lessc {
 		default:
 			$this->throwError("unknown op: {$prop[0]}\n");
 		}
-		$out->lines = array_unique($out->lines);
+		$out->lines = array_reverse(array_unique(array_reverse($out->lines)));
 	}
 
 


### PR DESCRIPTION
Inserted a new line in lessc.inc.php (line 711) to remove duplicate properties.  This should only remove properties in the same block that have the exact same values.

This ought to fix #233, where multiple imports of the same mixins would cause duplicate properties...  There may be a better way to fix this, but I'm not sure where it would happen.  This will also result in generally cleaner, more compact CSS.
