### PR TITLE
Support for Prefixr.com

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1683,6 +1683,23 @@ class lessc {
 		return false;
 	}
 
+	// query the prefixr.com api to optimise the css file
+	public function queryPrefixr($fname, $outFname = null) {
+		if (!is_readable($fname)) {
+			throw new Exception('load error: failed to find '.$fname);
+		}
+
+		$out = @fopen('http://prefixr.com/api/index.php?css='.urlencode(file_get_contents($fname)), "r");
+		if (!$out)
+		{
+			throw new Exception('load error: failed to query prefixr.com api');
+		}
+		if ($outFname !== null) {
+			return file_put_contents($outFname, $out);
+		}
+
+		return stream_get_contents($out);
+	}
 	/**
 	 * Execute lessphp on a .less file or a lessphp cache structure
 	 *


### PR DESCRIPTION
Hello,

i wrote a small function to query the api of www.prefixr.com .
I saw this function in the simpless compiler and thought it would be usefull for phpless too.
This patch only adds the function itself. so the user has to call it manually. I guess if this is accepted you could integrate it into some of the other functions. Maybe with an extra parameter to trigger it or something like that.

So what does prefixr.com do?
The site checks if some css functions are missing vendor prefixes and adds them / removes them if they are not needed anymore.

It's pretty usefull for people like me who are not sure which prefixes are needed :)

A pretty good example would be this css code:

``` css
#header {
  -webkit-border-radius: 5px;
  -moz-border-radius: 5px;
  -ms-border-radius: 5px;
  -o-border-radius: 5px;
  border-radius: 5px;
  -moz-transition: -moz-box-shadow 2s;
}
#footer {
  -webkit-border-radius: 10px;
  -moz-border-radius: 10px;
  -ms-border-radius: 10px;
  -o-border-radius: 10px;
  border-radius: 10px;
}
```

after passing it through prefixr it looks like this:

``` css
#header {
    border-radius: 5px;

    -webkit-transition: -webkit-box-shadow 2s;
    -moz-transition: -moz-box-shadow 2s;
    -o-transition: box-shadow 2s;
    -ms-transition: box-shadow 2s;
    transition: box-shadow 2s;
}

#footer {
    border-radius: 10px;
}
```

I hope this is usefull for someone :)

regards,
Haynes
