### PR TITLE
Declaration of lessify::parse() should be compatible with that of lessc::parse()

### DIFF
--- a/lessify.inc.php
+++ b/lessify.inc.php
@@ -363,7 +363,7 @@ class lessify extends lessc {
 		print_r($this->env);
 	}
 
-	public function parse($str = null) {
+	public function parse($str = null, $initialVariables = null) {
 		$this->prepareParser($str ? $str : $this->buffer);
 		while (false !== $this->parseChunk());
 


### PR DESCRIPTION
Hello,

I'm using PHP 5.3 and I got the following error:
Declaration of lessify::parse() should be compatible with that of lessc::parse()

The second parameter of the parse method was missed. Will be nice if it is fixed in the original repo.
