### PR TITLE
Add support for media query variables #335

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -327,6 +327,9 @@ class lessc {
 						$parts[] = "($q[1])";
 					}
 					break;
+				case "variable":
+					$parts[] = $this->compileValue($this->reduce($q));
+				break;
 				}
 			}
 
@@ -2574,6 +2577,9 @@ class lessc_parser {
 		{
 			$out = array("mediaExp", $feature);
 			if ($value) $out[] = $value;
+			return true;
+		}elseif($this->variable($variable)) {
+			$out = array('variable', $variable);
 			return true;
 		}
 


### PR DESCRIPTION
This adds support for variables within the media query

``` css
@mobile: ~"(max-width: 599px)";
@media @mobile{
    .test{
        width: 200px;
    }
}
```

Fixes Issue leafo/lessphp#335
