### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
     ],
     "autoload": {
         "classmap": ["lessc.inc.php"]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.3-dev"
+        }
     }
 }


### PR DESCRIPTION
This way people can require "0.3.*" and get stable vs unstable
versions depending on their minimum-stability, without having to
deal with the pains of dev-master.
