### PR TITLE
Minor typo in toRGB($color)

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1127,7 +1127,7 @@ class lessc {
 	 * Expects H to be in range of 0 to 360, S and L in 0 to 100
 	 */
 	protected function toRGB($color) {
-		if ($color == 'color') return $color;
+		if ($color[0] == 'color') return $color;
 
 		$H = $color[1] / 360;
 		$S = $color[2] / 100;


### PR DESCRIPTION
This fixes the check whether the argument passed to toRGB() is already an RGB value.
