### PR TITLE
Fix for #386: Format function (%) doesn't support uppercase placeholders

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -861,7 +861,7 @@ class lessc {
 		$template = $this->compileValue($this->lib_e($string));
 
 		$i = 0;
-		if (preg_match_all('/%[dsa]/', $template, $m)) {
+		if (preg_match_all('/%[dsaDSA]/', $template, $m)) {
 			foreach ($m[0] as $match) {
 				$val = isset($values[$i]) ?
 					$this->reduce($values[$i]) : array('keyword', '');
@@ -873,6 +873,9 @@ class lessc {
 
 				$i++;
 				$rep = $this->compileValue($this->lib_e($val));
+                if (ctype_upper(substr($match, 1))) {
+                    $rep = urlencode($rep);
+                }
 				$template = preg_replace('/'.self::preg_quote($match).'/',
 					$rep, $template, 1);
 			}


### PR DESCRIPTION
I have coded a solution for #386. Less.js uses encodeURIComponent() if the matched tag is uppercase, so I followed that logic and basically made 2 changes to the lib__sprintf() function:
- Changed the regex that looks for %d, %s or %a, so that it also will match uppercase tags
- If the match is uppercase, call urlencode() on the given $value
