### PR TITLE
Using square brackets instead of curly brackets to access string content

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -3061,7 +3061,7 @@ class lessc_parser {
 	protected function end() {
 		if ($this->literal(';')) {
 			return true;
-		} elseif ($this->count == strlen($this->buffer) || $this->buffer{$this->count} == '}') {
+		} elseif ($this->count == strlen($this->buffer) || $this->buffer[$this->count] == '}') {
 			// if there is end of file or a closing block next then we don't need a ;
 			return true;
 		}


### PR DESCRIPTION
Accessing Strings via Curly brackets will be deprecated in PHP6
http://php.net/manual/de/language.types.string.php#example-58 (above this example)

also i don't think it is as readable as brackets
