### PR TITLE
Make injectVariables compatible to other var Prefixes

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1621,7 +1621,7 @@ class lessc {
 		$this->pushEnv();
 		$parser = new lessc_parser($this, __METHOD__);
 		foreach ($args as $name => $strValue) {
-			if ($name{0} != '@') $name = '@'.$name;
+			if ($name{0} != $this->vPrefix) $name = $this->vPrefix.$name;
 			$parser->count = 0;
 			$parser->buffer = (string)$strValue;
 			if (!$parser->propertyValue($value)) {


### PR DESCRIPTION
injectVariables has still `@` as hard Coded Variable Prefix
