### PR TITLE
Made the third parameter of mix() optional to match less.js

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1017,19 +1017,24 @@ class lessc {
 	}
 
 	// mixes two colors by weight
-	// mix(@color1, @color2, @weight);
+	// mix(@color1, @color2, [@weight: 50%]);
 	// http://sass-lang.com/docs/yardoc/Sass/Script/Functions.html#mix-instance_method
 	protected function lib_mix($args) {
-		if ($args[0] != "list" || count($args[2]) < 3)
+		if ($args[0] != "list" || count($args[2]) < 2)
 			$this->throwError("mix expects (color1, color2, weight)");
 
-		list($first, $second, $weight) = $args[2];
+		list($first, $second) = $args[2];
 		$first = $this->assertColor($first);
 		$second = $this->assertColor($second);
 
 		$first_a = $this->lib_alpha($first);
 		$second_a = $this->lib_alpha($second);
-		$weight = $weight[1] / 100.0;
+
+		if (isset($args[2][2])) {
+			$weight = $args[2][2][1] / 100.0;
+		} else {
+			$weight = 0.5;
+		}
 
 		$w = $weight * 2 - 1;
 		$a = $first_a - $second_a;

--- a/tests/inputs/colors.less
+++ b/tests/inputs/colors.less
@@ -86,6 +86,7 @@ fade {
 
 .mix {
 	color: mix(@a, @b, 50%);
+	color: mix(@a, @b);
 	color: mix(rgba(5,3,1,0.3), rgba(6,3,2, 0.8), 50%);
 }
 

--- a/tests/outputs/colors.css
+++ b/tests/outputs/colors.css
@@ -58,6 +58,7 @@ fade {
 }
 .mix {
   color: #808080;
+  color: #808080;
   color: rgba(6,3,2,-0.25);
 }
 .contrast {


### PR DESCRIPTION
Closes #425

I applied the default value after resolving the percentage as I found it easier. Tell me if you prefer a different way to do it.
