### PR TITLE
set output precision to 16

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1653,6 +1653,7 @@ class lessc {
 	}
 
 	public function compile($string, $name = null) {
+		$precision = ini_set('precision', 16);
 		$locale = setlocale(LC_NUMERIC, 0);
 		setlocale(LC_NUMERIC, "C");
 
@@ -1675,6 +1676,7 @@ class lessc {
 		$this->formatter->block($this->scope);
 		$out = ob_get_clean();
 		setlocale(LC_NUMERIC, $locale);
+		ini_set('precision', $precision);
 		return $out;
 	}
 

--- a/tests/outputs/builtins.css
+++ b/tests/outputs/builtins.css
@@ -1,9 +1,9 @@
 body {
   color: "hello world";
-  height: 5.1666666666667;
+  height: 5.166666666666667;
   height: 5px;
   height: 6px;
-  width: 0.66666666666667;
+  width: 0.6666666666666666;
   width: 1;
   width: 0;
   width: 1;


### PR DESCRIPTION
proposed fix for #352 / #422

Tested with latest version of Bootstrap.  For the snippet posted by the OP, lessphp outputs:

```
.row-fluid [class*="span"] {
  display: block;
  width: 100%;
  min-height: 30px;
  -webkit-box-sizing: border-box;
  -moz-box-sizing: border-box;
  box-sizing: border-box;
  float: left;
  margin-left: 2.127659574468085%;
  *margin-left: 2.074468085106383%;
}
```
