### PR TITLE
Remove notice if block is not closed (#443)

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -2139,7 +2139,7 @@ class lessc_parser {
 			$this->throwError();
 
 		// TODO report where the block was opened
-		if (!is_null($this->env->parent))
+		if (!property_exists($this->env, 'parent') || !is_null($this->env->parent))
 			throw new exception('parse error: unclosed block');
 
 		return $this->env;


### PR DESCRIPTION
As reported in #443 an notice is being thrown if `$this->env->parent` is checked. I turned the proposed solution in a pull-request.
