### PR TITLE
Allows variables to be set using the plessc command.

### DIFF
--- a/plessc
+++ b/plessc
@@ -13,6 +13,7 @@ Options include:
     -h, --help  Show this message
     -v          Print the version
     -f=format   Set the output format, includes "default", "compressed"
+    -d=var:val  Set a less variable, may be used more than once
     -c          Keep /* */ comments in output
     -r          Read from STDIN instead of input-file
     -w          Watch input-file, and compile to output-file if it is changed
@@ -22,8 +23,8 @@ Options include:
 
 EOT;
 
-$opts = getopt('hvrwncXTf:', array('help'));
-while (count($argv) > 0 && preg_match('/^-([-hvrwncXT]$|[f]=)/', $argv[0])) {
+$opts = getopt('hvrwncXTf:d:', array('help'));
+while (count($argv) > 0 && preg_match('/^-([-hvrwncXT]$|[fd]=)/', $argv[0])) {
 	array_shift($argv);
 }
 
@@ -64,6 +65,28 @@ function make_less($fname = null) {
 		$format = $opts["f"];
 		if ($format != "default") $l->setFormatter($format);
 	}
+
+	if (has("d")) {
+		// Define variables
+		$vars = is_array($opts["d"]) ? $opts["d"] : array($opts["d"]);
+		$defs = array();
+		foreach ($vars as $var) {
+			// Each definition is $var:$val; the colon may be escaped if needed
+			$pair = preg_split('/(?<!\\\\):/', $var);
+			if (count($pair) == 2) {
+				$defs[$pair[0]] = $pair[1];
+			} else {
+				throw new Exception(
+					'Invalid variable definition "' . $var . '"; definitions'
+					. ' should be like "-d=variable_name:variable_value".'
+				);
+			}
+		}   
+
+		if (!empty($defs)) {
+			$l->setVariables($defs);
+		}
+	}   
 
 	if (has("c")) {
 		$l->setPreserveComments(true);


### PR DESCRIPTION
lessphp supports [setting variables from PHP][1], but the `plessc` command doesn't provide a way to do this.  This patch adds support for defining variables with the "-d" flag, e.g.

```bash
./plessc -d=foo:bar -d=blarg:w00t style.less
```

can be used to define the *foo* and *blarg* variables with "bar" and "w00t" respectively.

The same caveats as per usual apply to [setting less strings][1].  Note that, because colons are used for splitting the variable name and value, any literal colons should be escaped with a backslash, e.g.

```bash
./plessc -d=foo:bar\\:blarg style.less
# or
./plessc -d='foo:bar\:blarg' style.less
```

If the variable cannot be interpreted correctly (e.g. no colon, or multiple colons, found), then the command invocation will abort with an error.

[1]: http://leafo.net/lessphp/docs/#setting_variables_from_php