### PR TITLE
Make lessc::addParsedFile public

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1993,7 +1993,7 @@ class lessc {
 		return $this->allParsedFiles;
 	}
 
-	protected function addParsedFile($file) {
+	public function addParsedFile($file) {
 		$this->allParsedFiles[realpath($file)] = filemtime($file);
 	}
 


### PR DESCRIPTION
We extend lessc with a custom function that embeds small images in the
generated CSS as base64-encoded data URIs. It'd therefore be useful for us to
tie cache invalidation to the mtimes of these image files by invoking
addParsedFile from the custom function. This patch makes that possible by
changing the visibility of lessc::addParsedFile from protected to public.
