### PR TITLE
On invalid LESS, throw exception rather than emit blanks

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -62,8 +62,6 @@ class lessc {
 	protected $sourceParser = null;
 	protected $sourceLoc = null;
 
-	static public $defaultValue = array("keyword", "");
-
 	static protected $nextImportId = 0; // uniquely identify imports
 
 	// attempts to find the path of an import url, returns null for css files
@@ -684,8 +682,7 @@ class lessc {
 			$mixins = $this->findBlocks($block, $path, $orderedArgs, $keywordArgs);
 
 			if ($mixins === null) {
-				// fwrite(STDERR,"failed to find block: ".implode(" > ", $path)."\n");
-				break; // throw error here??
+				$this->throwError("{$prop[1][0]} is undefined");
 			}
 
 			foreach ($mixins as $mixin) {
@@ -959,7 +956,7 @@ class lessc {
 				if (isset($items[0])) {
 					return $this->lib_e($items[0]);
 				}
-				return self::$defaultValue;
+				$this->throwError("unrecognised input");
 			case "string":
 				$arg[1] = "";
 				return $arg;
@@ -1387,7 +1384,7 @@ class lessc {
 			}
 
 			$seen[$key] = true;
-			$out = $this->reduce($this->get($key, self::$defaultValue));
+			$out = $this->reduce($this->get($key));
 			$seen[$key] = false;
 			return $out;
 		case "list":
@@ -1746,7 +1743,7 @@ class lessc {
 
 
 	// get the highest occurrence entry for a name
-	protected function get($name, $default=null) {
+	protected function get($name) {
 		$current = $this->env;
 
 		$isArguments = $name == $this->vPrefix . 'arguments';
@@ -1763,7 +1760,7 @@ class lessc {
 			}
 		}
 
-		return $default;
+		$this->throwError("variable $name is undefined");
 	}
 
 	// inject array of unparsed strings into environment as variables

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -1,0 +1,81 @@
+<?php
+require_once __DIR__ . "/../lessc.inc.php";
+
+class ErrorHandlingTest extends PHPUnit_Framework_TestCase {
+	public function setUp() {
+		$this->less = new lessc();
+	}
+
+	public function compile() {
+		$source = join("\n", func_get_args());
+		return $this->less->compile($source);
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage .parametric-mixin is undefined
+	 */
+	public function testRequiredParametersMissing() {
+		$this->compile(
+			'.parametric-mixin (@a, @b) { a: @a; b: @b; }',
+			'.selector { .parametric-mixin(12px); }'
+		);
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage .parametric-mixin is undefined
+	 */
+	public function testTooManyParameters() {
+		$this->compile(
+			'.parametric-mixin (@a, @b) { a: @a; b: @b; }',
+			'.selector { .parametric-mixin(12px, 13px, 14px); }'
+		);
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage unrecognised input
+	 */
+	public function testRequiredArgumentsMissing() {
+		$this->compile('.selector { rule: e(); }');
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage variable @missing is undefined
+	 */
+	public function testVariableMissing() {
+		$this->compile('.selector { rule: @missing; }');
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage .missing-mixin is undefined
+	 */
+	public function testMixinMissing() {
+		$this->compile('.selector { .missing-mixin; }');
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage .flipped is undefined
+	 */
+	public function testGuardUnmatchedValue() {
+		$this->compile(
+			'.flipped(@x) when (@x =< 10) { rule: value; }',
+			'.selector { .flipped(12); }'
+		);
+	}
+
+	/**
+	 * @expectedException        Exception
+	 * @expectedExceptionMessage .colors-only is undefined
+	 */
+	public function testGuardUnmatchedType() {
+		$this->compile(
+			'.colors-only(@x) when (iscolor(@x)) { rule: value; }',
+			'.selector { .colors-only("string value"); }'
+		);
+	}
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,12 @@
 lessphp uses [phpunit](https://github.com/sebastianbergmann/phpunit/) for its tests
 
-`InputTest.php` iterates through all the less files in `inputs/`, compiles them,
-then compares the result with the respective file in `outputs/`.
+* `InputTest.php` iterates through all the less files in `inputs/`, compiles
+  them, then compares the result with the respective file in `outputs/`.
+
+* `ApiTest.php` tests the behavior of lessphp's public API methods.
+
+* `ErrorHandlingTest.php` tests that lessphp throws appropriate errors when
+  given invalid LESS as input.
 
 From the root you can run `make` to run all the tests.
 

--- a/tests/inputs/escape.less
+++ b/tests/inputs/escape.less
@@ -7,7 +7,6 @@ body {
 	e4: e(1232);
 	e5: e(@hello);
 	e6: e("one" + 'more');
-	e7: e();
 
 	t1: ~"eating rice";
 	t2: ~"string cheese";

--- a/tests/inputs/guards.less
+++ b/tests/inputs/guards.less
@@ -33,7 +33,6 @@
 
 dd {
 	.simple(true);
-	.simple(2344px);
 }
 
 b {
@@ -43,18 +42,12 @@ b {
 
 img {
 	.another(12);
-	.another(2);
-
-	.flipped(12);
 	.flipped(2);
 }
 
 body {
-	.yeah("world");
 	.yeah(232px);
 	.yeah(232);
-
-	.hello(true);
 }
 
 .something(@x) when (@x) and (@y), not (@x = what) {
@@ -67,18 +60,12 @@ div {
 
 }
 
-pre {
-	.something(what);
-}
-
 .coloras(@g) when (iscolor(@g)) {
 	color: true @g;
 }
 
 link {
 	.coloras(red);
-	.coloras(10px);
-	.coloras(ffjref);
 	.coloras(#fff);
 	.coloras(#fffddd);
 	.coloras(rgb(0,0,0));

--- a/tests/inputs/misc.less
+++ b/tests/inputs/misc.less
@@ -48,8 +48,6 @@ Here is a block comment
 .cool {.mix("@{aaa}, @{bbb}")}
 .cool();
 
-.cool("{hello");
-.cool('{hello');
 
 
 // merging of mixins

--- a/tests/inputs/mixins.less
+++ b/tests/inputs/mixins.less
@@ -61,11 +61,6 @@ body {
 }
 
 
-.butter {
-	.this .one .isnt .found;
-}
-
-
 // arguments
 
 .spam(@something: 100, @dad: land) {

--- a/tests/inputs/pattern_matching.less
+++ b/tests/inputs/pattern_matching.less
@@ -117,7 +117,6 @@
 
 #hola {
 	.hola(hello, world);
-	.hola(jello, world);
 }
 
 .resty(@hello, @world, @the_rest...) {
@@ -125,20 +124,11 @@
 	rest: @the_rest;
 }
 
-#nnn {
-	.body(10, 10, 10, 10, 10);
-	.body(10, 10, 10);
-	.body(10, 10);
-	.body(10);
-	.body();
-}
-
 .defaults(@aa, @bb:e343, @cc: "heah", ...) {
 	height: @aa;
 }
 
 #defaults_1 {
-	.defaults();
 	.defaults(one);
 	.defaults(two, one);
 	.defaults(three, two, one);

--- a/tests/inputs/variables.less
+++ b/tests/inputs/variables.less
@@ -32,7 +32,6 @@
   color: @c;
   border: 1px solid @rgb-color;
   background: @rgba-color;
-  padding: @nonexistant + 4px;
 }
 
 @hello: 44px;

--- a/tests/outputs/escape.css
+++ b/tests/outputs/escape.css
@@ -5,7 +5,6 @@ body {
   e4: 1232;
   e5: world;
   e6: onemore;
-  e7: ;
   t1: eating rice;
   t2: string cheese;
   t3: a b c string me d e f;

--- a/tests/outputs/variables.css
+++ b/tests/outputs/variables.css
@@ -16,5 +16,4 @@ outer2: 44px;
   color: #888;
   border: 1px solid #3326cc;
   background: rgba(23,68,149,0.5);
-  padding: 4px;
 }


### PR DESCRIPTION
This patch makes lessphp throw errors when it is called to compile LESS code
that references undefined variables or mixins. A mixin invocation will cause an
exception to be thrown if it fails to match, whether it is because no mixin of
that name exists, or because the invocation fails to match against the
signatures or guards of defined mixins. This is consistent with the behavior of
the reference LESS implementation.

The patch removes cases from tests/inputs/\* that fail to compile. A new test
suite, ErrorHandlingTest.php, verifies the new error-throwing behavior.
