### PR TITLE
Update lessc.inc.php

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -2310,7 +2310,7 @@ class lessc_parser {
 			$this->throwError();
 
 		// TODO report where the block was opened
-		if (!is_null($this->env->parent))
+		if ( !property_exists($this->env, 'parent') || !is_null($this->env->parent) ) 
 			throw new exception('parse error: unclosed block');
 
 		return $this->env;


### PR DESCRIPTION
use property_exist to avoid the inconsistent error message:
"Undefined property: stdClass::$parent"
when error reporting is set to ALL

in this error case:
# header .logo {position:relative; }

}
