### PR TITLE
Update lessc.inc.php

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1208,7 +1208,7 @@ class lessc {
 	protected function lib_contrast($args) {
 	    $darkColor  = array('color', 0, 0, 0);
 	    $lightColor = array('color', 255, 255, 255);
-	    $threshold  = 0.42;
+	    $threshold  = 0.43;
 	     
 	    if ( $args[0] == 'list' ) {
 	        $inputColor = ( isset($args[2][0]) ) ? $this->assertColor($args[2][0])  : $lightColor;


### PR DESCRIPTION
Fix: color: contrast(#000); generate error because light and dark was not optional, the contrast function not act like lesscss.org documentation.
also the thresold is fixed and not implemented like less.js

this change:
- make optional light color, dark color and threshold
- threshold act like less.js implementation
- add lib_luma (for threshold calculation)
