### PR TITLE
Bug: mixin recursion (a test case included)

### DIFF
--- a/tests/inputs/mixin_recursive.less
+++ b/tests/inputs/mixin_recursive.less
@@ -1,0 +1,15 @@
+// This test for mixin recursion (loops).
+
+.bg(@filename)
+{
+  background-image: url('@{filename}');
+}
+
+.generate_nav(@n; @i: 1) when (@i =< @n) {
+  #but@{i} {
+    .bg('@{i}.png');
+  }
+  .generate_nav(@n; (@i+1));
+}
+
+.generate_nav(5);

--- a/tests/outputs/mixin_recursive.css
+++ b/tests/outputs/mixin_recursive.css
@@ -1,0 +1,15 @@
+#but1 {
+  background-image: url('1.png');
+}
+#but2 {
+  background-image: url('2.png');
+}
+#but3 {
+  background-image: url('3.png');
+}
+#but4 {
+  background-image: url('4.png');
+}
+#but5 {
+  background-image: url('5.png');
+}


### PR DESCRIPTION
The stable version of lessphp doesn't support a recursion loop. But an online version compiles it without a single error. I've included a test case.
