### PR TITLE
Adding the configuration to be able to build a less.phar command

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,0 +1,6 @@
+{
+    "files": ["lessc.inc.php", "lessify", "lessify.inc.php"],
+    "main": "plessc",
+    "output": "less.phar",
+    "stub": true
+}

--- a/plessc
+++ b/plessc
@@ -40,9 +40,8 @@ if (has("h", "help")) {
 }
 
 error_reporting(E_ALL);
-$path  = realpath(dirname(__FILE__)).'/';
 
-require $path."lessc.inc.php";
+require "lessc.inc.php";
 
 $VERSION = lessc::$VERSION;
 


### PR DESCRIPTION
Now using box (http://box-project.org/), you can create a phar archive to use less php anywhere.
You just need to do run box build in the project root folder, then "chmod +x less.phar" and your done.
