### PR TITLE
Better variable inheritance

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1836,7 +1836,7 @@ class lessc {
 		$current = $this->env;
 
 		// track scope to evaluate
-		$scope_secondary = [];
+		$scope_secondary = array();
 
 		$isArguments = $name == $this->vPrefix . 'arguments';
 		while ($current) {


### PR DESCRIPTION
I was seeing a problem compiling Bootstrap 2.3.2 where the fluid widths were not correctly preserved in the responsive design. This was due to an issue where the mixin scope took precedence over the normal variable inheritance chain. This commit ensures that the standard inheritance chain is fully traversed before considering mixin scope.

There is likely a more graceful way to do this, but I did at least want to offer this solution in case others are running into the same issue.
