### PR TITLE
is_file Warnings

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -78,7 +78,7 @@ class lessc {
 	}
 
 	protected function fileExists($name) {
-		return is_file($name);
+		return @is_file($name);
 	}
 
 	static public function compressList($items, $delim) {


### PR DESCRIPTION
I've came across situations where findImport was walking out of open_basedir (i.e.: Joomla! 3.4) and i thought it would be the best idea to disable only that Warning instead of disabling all Warnings.

Please consider adding this change (or something similar) to your project, so i don't have to apply that patch to every after every update :)

Thanks!
