### PR TITLE
Update plessc

### DIFF
--- a/plessc
+++ b/plessc
@@ -246,5 +246,3 @@ try {
 	err($fa.$ex->getMessage());
 	exit(1);
 }
-
-?>


### PR DESCRIPTION
remove PHP close tag. not necessary since php 4.0
