### PR TITLE
Allow parsing multiple strings using same imports.

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1888,6 +1888,7 @@ class lessc {
 
 		$this->env = null;
 		$this->scope = null;
+		$this->allParsedFiles = array();
 
 		$this->formatter = $this->newFormatter();
 


### PR DESCRIPTION
If you use a single Less instance to parse multiple strings and these strings share `@import` statements, only the first `parse` will actually execute the `@import`.