### PR TITLE
Add the "length" function to lessphp

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1018,6 +1018,7 @@ class lessc {
 
         protected function lib_length($args)
         {
+            $this->assertArgs($args);
             return count($args[2]);
         }
         
@@ -1293,14 +1294,14 @@ class lessc {
 		$this->throwError($error);
 	}
 
-	public function assertArgs($value, $expectedArgs, $name="") {
+	public function assertArgs($value, $expectedArgs = null, $name="") {
 		if ($expectedArgs == 1) {
 			return $value;
 		} else {
 			if ($value[0] !== "list" || $value[1] != ",") $this->throwError("expecting list");
 			$values = $value[2];
 			$numValues = count($values);
-			if ($expectedArgs != $numValues) {
+			if ($expectedArgs && $expectedArgs != $numValues) {
 				if ($name) {
 					$name = $name . ": ";
 				}

--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1016,6 +1016,11 @@ class lessc {
 		return 'url("'.$url.'")';
 	}
 
+        protected function lib_length($args)
+        {
+            return count($args[2]);
+        }
+        
 	// utility func to unquote a string
 	protected function lib_e($arg) {
 		switch ($arg[0]) {


### PR DESCRIPTION
Add the famous "length" lib function to lessphp (http://lesscss.org/functions/#list-functions).

Required to use loops like this example: https://github.com/seven-phases-max/less.curious/blob/master/src/for.less, http://webdesign.tutsplus.com/tutorials/understanding-the-less-loop--cms-23827, .. or other stuff.
