### PR TITLE
Fixed PHP 7 compat issue

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -2735,7 +2735,7 @@ class lessc_parser {
 		if ($this->unit($value)) return true;
 		if ($this->color($value)) return true;
 		if ($this->func($value)) return true;
-		if ($this->string($value)) return true;
+		if ($this->stringValue($value)) return true;
 
 		if ($this->keyword($word)) {
 			$value = array('keyword', $word);
@@ -2749,7 +2749,7 @@ class lessc_parser {
 		}
 
 		// unquote string (should this work on any type?
-		if ($this->literal("~") && $this->string($str)) {
+		if ($this->literal("~") && $this->stringValue($str)) {
 			$value = array("escape", $str);
 			return true;
 		} else {
@@ -2879,7 +2879,7 @@ class lessc_parser {
 				}
 			}
 
-			if (($tok == "'" || $tok == '"') && $this->string($str)) {
+			if (($tok == "'" || $tok == '"') && $this->stringValue($str)) {
 				$content[] = $str;
 				continue;
 			}
@@ -2910,7 +2910,7 @@ class lessc_parser {
 		return true;
 	}
 
-	protected function string(&$out) {
+	protected function stringValue(&$out) {
 		$s = $this->seek();
 		if ($this->literal('"', false)) {
 			$delim = '"';
@@ -3163,7 +3163,7 @@ class lessc_parser {
 					$attrParts[] = " ";
 					continue;
 				}
-				if ($this->string($str)) {
+				if ($this->stringValue($str)) {
 					// escape parent selector, (yuck)
 					foreach ($str[2] as &$chunk) {
 						$chunk = str_replace($this->lessc->parentSelector, "$&$", $chunk);

--- a/lessify.inc.php
+++ b/lessify.inc.php
@@ -118,7 +118,7 @@ class tagparse extends easyparse {
 		return ob_get_clean();
 	}
 
-	function string(&$out) {
+	function stringValue(&$out) {
 		$s = $this->seek();
 
 		if ($this->literal('"')) {
@@ -231,7 +231,7 @@ class tagparse extends easyparse {
 	}
 
 	function value(&$out) {
-		if ($this->string($str)) {
+		if ($this->stringValue($str)) {
 			$out = $this->compileString($str);
 			return true;
 		} elseif ($this->ident($id)) {


### PR DESCRIPTION
It seems 'string' is a reserved keyword [introduced](http://php.net/manual/en/reserved.other-reserved-words.php) in PHP version 7.0.