### PR TITLE
tests: Drop PHP 5.3 from matrix, add PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+
+matrix:
+  allow_failures:
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
 
 sudo: false
 


### PR DESCRIPTION
PHP 5.3 is EOL, and composer no longer supports it.

For Travis CI, the build is also failing outstanding PRs due to
PHP 5.3 requiring Ubuntu Precise (also EOL), whereas the
default image uses uses Ubuntu Trusty.
