### PR TITLE
Added patch for CSS named grids

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -2452,6 +2452,7 @@ class lessc_parser {
     }
 
     public function parse($buffer) {
+        $buffer = preg_replace('/\[([\w-]+)\]/', '___$1___', $buffer); // Protect CSS named grids
         $this->count = 0;
         $this->line = 1;
 

--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1988,6 +1988,8 @@ class lessc {
     }
 
     public function compile($string, $name = null) {
+        $string = preg_replace('/\[([\w-]+)\]/', '___$1___', $string); // Protect CSS named grids
+        
         $locale = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, "C");
 
@@ -2010,6 +2012,7 @@ class lessc {
         $this->formatter->block($this->scope);
         $out = ob_get_clean();
         setlocale(LC_NUMERIC, $locale);
+        $out = preg_replace('/___([\w-]+)___/', '[$1]', $out); // Remove CSS named grid protections
         return $out;
     }
 


### PR DESCRIPTION
This adds a patch to lessc->compile that adds a protection to CSS named grids. Once all other parsing is done successfully the protection is removed and the compiled CSS returned.

The protection is a rough patch that removes brackets and replaces them with 3 underscores so [grid-name] becomes \_\_\_grid-name\_\_\_ which does not trigger any parser errors allowing everything to be parsed as normal. If this patch is added into lessphp permanently I would suggest doing 4 underscores for (paranoia) safeties sake or a different pattern that is still safe to parse but less common to be used in someones code.