### PR TITLE
Fix Issue 673: Parse error with named CSS grid lines and areas

### DIFF
--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -2452,6 +2452,7 @@ class lessc_parser {
     }
 
     public function parse($buffer) {
+        $buffer = preg_replace('/\[([\w-]+)\]/', '___$1___', $buffer); // Protect CSS named grids
         $this->count = 0;
         $this->line = 1;
 

--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * lessphp v0.5.0
  * http://leafo.net/lessphp
@@ -9,7 +8,6 @@
  * Copyright 2013, Leaf Corcoran <leafot@gmail.com>
  * Licensed under MIT or GPLv3, see LICENSE
  */
-
 
 /**
  * The LESS compiler and parser.
@@ -1989,7 +1987,6 @@ class lessc {
 
     public function compile($string, $name = null) {
         $string = preg_replace('/\[([\w-]+)\]/', '___$1___', $string); // Protect CSS named grids
-        
         $locale = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, "C");
 
@@ -2452,6 +2449,7 @@ class lessc_parser {
     }
 
     public function parse($buffer) {
+        // lessc->compile() will handle unprotecting CSS named grids.
         $buffer = preg_replace('/\[([\w-]+)\]/', '___$1___', $buffer); // Protect CSS named grids
         $this->count = 0;
         $this->line = 1;

--- a/lessc.inc.php
+++ b/lessc.inc.php
@@ -1988,6 +1988,8 @@ class lessc {
     }
 
     public function compile($string, $name = null) {
+        $string = preg_replace('/\[([\w-]+)\]/', '___$1___', $string); // Protect CSS named grids
+        
         $locale = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, "C");
 
@@ -2010,6 +2012,7 @@ class lessc {
         $this->formatter->block($this->scope);
         $out = ob_get_clean();
         setlocale(LC_NUMERIC, $locale);
+        $out = preg_replace('/___([\w-]+)___/', '[$1]', $out); // Remove CSS named grid protections
         return $out;
     }
 


### PR DESCRIPTION
This patch protects CSS named grids by replacing the brackets before any parsing or compiling happens. Once all parsing and compiling is done the brackets are replaced. 

**NOTE**
Brackets are changed to 3 underscores [grid-name] => \_\_\_grid-name\_\_\_ which works great but has a small chance of clashing with someones code, in this case I would suggest changing it to 4 underscores. Who is writing that many in their less/ css?